### PR TITLE
changing lastParsedData property to hold an entirely new object, whic…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-json-edit",
-  "version": "1.3.4",
+  "version": "1.4.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4848,6 +4848,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
       "dev": true
+    },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
     },
     "loglevel": {
       "version": "1.6.1",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   },
   "dependencies": {
     "highlight.js": "^9.15.6",
+    "lodash.clonedeep": "^4.5.0",
     "vue": "^2.6.8",
     "vuedraggable": "^2.23.2"
   },

--- a/src/JsonEditor.vue
+++ b/src/JsonEditor.vue
@@ -6,6 +6,7 @@
 
 <script>
 import JsonView from "./JsonView.vue";
+import cloneDeep from "lodash.clonedeep";
 
 export default {
   name: "JsonEditor",
@@ -50,7 +51,7 @@ export default {
           return;
         }
 
-        this.lastParsedData = newValue;
+        this.lastParsedData = cloneDeep(newValue);
         this.$emit("input", this.makeJson(this.parsedData));
       },
       deep: true


### PR DESCRIPTION
Fixes jinkin1995/vue-json-edit#33

changing lastParsedData to hold an entirely new object, which is cloned from the new value of parsedData, so that the comparison of newValue to lastParsedData would return false, in case user edits the json object with the provided editor.

Otherwise lastParsedData would be holding an reference to parsedData object, and when parsedData changes lastParsedData would automatically reflect those changes which always return before emitting input event from the watcher on parsedData property